### PR TITLE
Feature: Add supplementary metadata for file types

### DIFF
--- a/classes/extractor.php
+++ b/classes/extractor.php
@@ -111,7 +111,7 @@ class extractor extends \tool_metadata\extractor {
     /**
      * Table name for storing extracted metadata for this extractor.
      */
-    const METADATA_TABLE = 'metadataextractor_tika';
+    const METADATA_BASE_TABLE = 'metadataextractor_tika';
 
     /**
      * Local Tika service type: Java and a Tika application jar are installed locally, plugin will use direct commands to CLI.
@@ -175,7 +175,7 @@ class extractor extends \tool_metadata\extractor {
         }
 
         if (!empty($metadataarray) && is_array($metadataarray)) {
-            $result = new metadata(helper::get_resourcehash($file, TOOL_METADATA_RESOURCE_TYPE_FILE), $metadataarray, true);
+            $result = new metadata(0, helper::get_resourcehash($file, TOOL_METADATA_RESOURCE_TYPE_FILE), $metadataarray);
         }
 
         return $result;
@@ -215,7 +215,7 @@ class extractor extends \tool_metadata\extractor {
         }
 
         if (!empty($metadataarray) && is_array($metadataarray)) {
-            $result = new metadata(helper::get_resourcehash($url, TOOL_METADATA_RESOURCE_TYPE_URL), $metadataarray, true);
+            $result = new metadata(0, helper::get_resourcehash($url, TOOL_METADATA_RESOURCE_TYPE_URL), $metadataarray);
         }
 
         return $result;

--- a/classes/metadata.php
+++ b/classes/metadata.php
@@ -38,6 +38,11 @@ defined('MOODLE_INTERNAL') || die();
 class metadata extends \tool_metadata\metadata {
 
     /**
+     * The table name where metadata records are stored.
+     */
+    const TABLE = 'metadataextractor_tika';
+
+    /**
      * @var string The person or organization primarily responsible for creating the
      * intellectual content of the resource this metadata represents.
      */
@@ -90,16 +95,6 @@ class metadata extends \tool_metadata\metadata {
      * @var string The language of the resource.
      */
     public $language;
-
-    /**
-     * @var int The UNIX timestamp of when instance was created.
-     */
-    public $timecreated;
-
-    /**
-     * @var int The UNIX timestamp of when instance was last modified.
-     */
-    public $timemodified;
 
     protected function metadata_key_map() {
 

--- a/classes/metadata.php
+++ b/classes/metadata.php
@@ -15,7 +15,7 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
- * Define the core metadata model for all resources.
+ * The base metadata model for all tika extracted metadata.
  *
  * @package    tool_metadata
  * @copyright  2019 Tom Dickman <tomdickman@catalyst-au.net>
@@ -24,12 +24,12 @@
 
 namespace metadataextractor_tika;
 
+use tool_metadata\metadata_exception;
+
 defined('MOODLE_INTERNAL') || die();
 
 /**
- * The core metadata model for all resources.
- *
- * This model follows a modified version of Dublin Core tailored for Moodle.
+ * The base metadata model for all tika extracted metadata.
  *
  * @package    tool_metadata
  * @copyright  2019 Tom Dickman <tomdickman@catalyst-au.net>
@@ -41,6 +41,11 @@ class metadata extends \tool_metadata\metadata {
      * The table name where metadata records are stored.
      */
     const TABLE = 'metadataextractor_tika';
+
+    /*
+     * The table name where supplementary metadata is stored.
+     */
+    const SUPPLEMENTARY_TABLE = '';
 
     /**
      * @var string The person or organization primarily responsible for creating the
@@ -96,8 +101,58 @@ class metadata extends \tool_metadata\metadata {
      */
     public $language;
 
+    /**
+     * Get the supplementary table for metadata instance.
+     *
+     * @return string
+     */
+    public function get_supplementary_table() {
+        return static::SUPPLEMENTARY_TABLE;
+    }
+
+    /**
+     * Does this metadata class have supplementary data in addition
+     * to base metadata data?
+     *
+     * @return bool
+     */
+    public function has_supplementary_data() {
+        $result = false;
+
+        if (!empty(static::SUPPLEMENTARY_TABLE)) {
+            $result = true;
+        }
+
+        return $result;
+    }
+
+    /**
+     * @inheritDoc
+     */
     protected function metadata_key_map() {
 
+        // Use late static binding for supplementary_key_map only as we always
+        // want base_key_map to reflect the key map defined in this class.
+        return array_merge(self::base_key_map(), static::supplementary_key_map());
+    }
+
+    /**
+     * Return the mapping of base metadata variables for this metadata class which
+     * all extending metadata classes will inherit.
+     *
+     * Example:
+     *  [
+     *      'author' => [
+     *           'Author', 'meta:author', 'Creator', 'meta:creator', 'dc:creator',
+     *       ],
+     *      'title' => [
+     *           'Title', 'meta:title', 'dc:title',
+     *       ]
+     *  ]
+     *
+     * @return array
+     */
+    protected function base_key_map() {
         return [
             'format' => ['dc:format', 'Content-Type'],
             'type' => ['dc:type'],
@@ -108,8 +163,259 @@ class metadata extends \tool_metadata\metadata {
             'contributor' => ['dc:contributor', 'meta:last-author'],
             'subject' => ['dc:subject', 'Subject', 'subject', 'meta:subject', 'Keywords', 'meta:keyword'],
             'publisher' => ['dc:publisher', 'Publisher', 'publisher', 'meta:publisher'],
-            'rights' => ['dc:rights', 'Rights', 'rights', 'meta:rights', 'License', 'license', 'meta:license'],
+            'rights' => ['dc:rights', 'Rights', 'rights', 'meta:rights', 'License', 'license', 'meta:license',
+                'Copyright', 'copyright', 'meta:copyright',  'custom:Rights', 'custom:rights',
+                'custom:Copyright', 'custom:copyright', 'custom:License', 'custom:licence',
+                'extended-properties:Rights', 'extended-properties:rights', 'extended-properties:Copyright',
+                'extended-properties:copyright', 'extended-properties:License', 'extended-properties:licence'],
             'language' => ['dc:language', 'Language', 'language', 'meta:language'],
         ];
+    }
+
+    /**
+     * Return the mapping of extending class additional variables which are supplementary to this
+     * metadata class's variables.
+     *
+     * Example:
+     *  [
+     *      'pagecount' => [
+     *           'Page-Count', 'meta:page-count', 'xmpTPg:NPages',
+     *       ],
+     *      'wordcount' => [
+     *           'Word-Count', 'meta:word-count',
+     *       ]
+     *  ]
+     *
+     * @return array
+     */
+    protected function supplementary_key_map() {
+        return [];
+    }
+
+    /**
+     * Populate this instance by ID of base metadata record.
+     *
+     * @param int $id the id of the base metadata record to populate metadata from.
+     *
+     * @return bool $success true if populated successfully, false otherwise.
+     */
+    protected function populate_from_id(int $id): bool {
+        global $DB;
+
+        // Populate base variables.
+        $success = parent::populate_from_id($id);
+
+        // Populate supplementary data variables if instance has any.
+        if ($success && $this->has_supplementary_data()) {
+            $record = $DB->get_record($this->get_supplementary_table(), ['resourcehash' => $this->resourcehash]);
+            if (!empty($record)) {
+                foreach ((array) $record as $property => $value) {
+                    // Prevent overriding of instance ID with supplementary record ID.
+                    if ($property != 'id') {
+                        $this->$property = $value;
+                    }
+                }
+                $success = true;
+            } else {
+                $success = false;
+            }
+        }
+
+        return $success;
+    }
+
+    /**
+     * Populate the variables of this metadata instance from an existing database records by resourcehash.
+     *
+     * @param string $resourcehash the resourcehash of the resource to populate metadata for.
+     *
+     * @return bool $success true if populated successfully, false otherwise.
+     */
+    public function populate_from_resourcehash(string $resourcehash): bool {
+        global $DB;
+
+        // Populate base variables.
+        $success = parent::populate_from_resourcehash($resourcehash);
+
+        // Populate supplementary data variables if instance has any.
+        if ($success && $this->has_supplementary_data()) {
+            $record = $DB->get_record($this->get_supplementary_table(), ['resourcehash' => $resourcehash]);
+            if (!empty($record)) {
+                foreach ((array) $record as $property => $value) {
+                    // Prevent overriding of instance ID with supplementary record ID.
+                    if ($property != 'id') {
+                        $this->$property = $value;
+                    }
+                }
+                $success = true;
+            } else {
+                $success = false;
+            }
+        }
+        return $success;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function get_record() {
+        $recordarray = array_merge((array) $this->get_base_record(), (array) $this->get_supplementary_record());
+        $record = (object) $recordarray;
+
+        return $record;
+    }
+
+    /**
+     * Get the base data of this metadata instance as a
+     * record for database handling.
+     *
+     * @return \stdClass
+     */
+    protected function get_base_record() {
+        $record = new \stdClass();
+
+        if (!empty($this->id)) {
+            $record->id = $this->id;
+        } else {
+            $record->id = 0;
+        }
+
+        $record->resourcehash = $this->resourcehash;
+        $record->timecreated = $this->timecreated;
+        $record->timemodified = $this->timemodified;
+
+        $keys = array_keys(self::base_key_map());
+
+        foreach ($keys as $key) {
+            $record->$key = $this->$key;
+        }
+
+        return $record;
+    }
+
+    /**
+     * Get the supplementary data of this metadata instance as
+     * a record for database handling.
+     *
+     * @return \stdClass this instances supplementary data
+     */
+    protected function get_supplementary_record() {
+        $record = new \stdClass();
+        $record->id = $this->get_supplementary_id();
+        $record->resourcehash = $this->resourcehash;
+
+        $keys = array_keys(static::supplementary_key_map());
+
+        foreach ($keys as $key) {
+            $record->$key = $this->$key;
+        }
+
+        return $record;
+    }
+
+    /**
+     * Get the ID of the supplementary data record for this metadata instance.
+     *
+     * @return int the ID of the supplementary record for this metadata instance.
+     */
+    public function get_supplementary_id() {
+        global $DB;
+
+         $result = $DB->get_field($this->get_supplementary_table(), 'id', ['resourcehash' => $this->resourcehash]);
+
+         if (!empty($result)) {
+             $id = $result;
+         } else {
+             $id = 0;
+         }
+
+         return $id;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function create() {
+        global $DB;
+
+        $baserecord = $this->get_base_record();
+
+        if (!empty($baserecord->id)) {
+            $exists = $DB->get_record($this->get_table(), ['id' => $baserecord->id]);
+            if ($exists) {
+                throw new metadata_exception('error:metadata:recordalreadyexists');
+            }
+        }
+
+        if (empty($baserecord->timecreated)) {
+            $baserecord->timecreated = $this->timecreated = time();
+        }
+        $baserecord->timemodified = $this->timemodified = time();
+
+        $transaction = $DB->start_delegated_transaction();
+        $id = $DB->insert_record($this->get_table(), $baserecord);
+
+        if ($this->has_supplementary_data()) {
+            $supplementaryrecord = $this->get_supplementary_record();
+            $DB->insert_record($this->get_supplementary_table(), $supplementaryrecord);
+        }
+
+        $transaction->allow_commit();
+
+        $this->id = $id;
+
+        return $this;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function update() {
+        global $DB;
+
+        $baserecord = $this->get_base_record();
+
+        if (!empty($baserecord->id)) {
+            $baserecord->timemodified = time();
+            $transaction = $DB->start_delegated_transaction();
+            $success = $DB->update_record($this->get_table(), $baserecord);
+        } else {
+            throw new metadata_exception('error:metadata:noid');
+        }
+
+        if ($success && $this->has_supplementary_data()) {
+            $supplementaryrecord = $this->get_supplementary_record();
+            $success = $DB->update_record($this->get_supplementary_table(), $supplementaryrecord);
+        }
+
+        if ($success) {
+            $transaction->allow_commit();
+        }
+
+        return $success;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function delete() {
+        global $DB;
+
+        $transaction = $DB->start_delegated_transaction();
+        $success = parent::delete();
+
+        if ($success && $this->has_supplementary_data()) {
+            $id = $this->get_supplementary_id();
+            if (empty($id)) {
+                throw new metadata_exception('error:metadata:noid');
+            }
+            $success = $DB->delete_records($this->get_supplementary_table(), ['id' => $id]);
+        }
+
+        if ($success) {
+            $transaction->allow_commit();
+        }
+
+        return $success;
     }
 }

--- a/classes/metadata_document.php
+++ b/classes/metadata_document.php
@@ -1,0 +1,96 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * The metadata model for document files.
+ *
+ * @package    tool_metadata
+ * @copyright  2019 Tom Dickman <tomdickman@catalyst-au.net>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace metadataextractor_tika;
+
+defined('MOODLE_INTERNAL') || die();
+
+/**
+ * The metadata model for document files.
+ *
+ * This model follows a modified version of Dublin Core tailored for Moodle.
+ *
+ * @package    tool_metadata
+ * @copyright  2019 Tom Dickman <tomdickman@catalyst-au.net>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class metadata_document extends \metadataextractor_tika\metadata {
+
+    /**
+     * @var int the page count of document.
+     */
+    public $pagecount;
+
+    /**
+     * @var int the paragraph count of document.
+     */
+    public $paragraphcount;
+
+    /**
+     * @var int the line count of document.
+     */
+    public $linecount;
+
+    /**
+     * @var int the word count of document.
+     */
+    public $wordcount;
+
+    /**
+     * @var int the character count of document (excluding spaces).
+     */
+    public $charactercount;
+
+    /**
+     * @var int the character count of document (including spaces).
+     */
+    public $charactercountwithspaces;
+
+    /**
+     * @var string the name of document manager.
+     */
+    public $manager;
+
+    /**
+     * @var string the name of company document belongs to or was authored by.
+     */
+    public $company;
+
+    const SUPPLEMENTARY_TABLE = 'tika_document_metadata';
+
+    protected function supplementary_key_map() {
+        return [
+            'pagecount' => ['Page-Count', 'meta:page-count', 'xmpTPg:NPages'],
+            'linecount' => ['Line-Count', 'meta:line-count'],
+            'paragraphcount' => ['Paragraph-Count', 'meta:paragraph-count'],
+            'wordcount' => ['Word-Count', 'meta:word-count'],
+            'charactercount' => ['Character-Count', 'meta:character-count'],
+            'charactercountwithspaces' => ['Character-Count-With-Spaces', 'meta:character-count-with-spaces'],
+            'manager' => ['Manager', 'meta:manager', 'meta:Manager', 'custom:manager', 'custom:Manager',
+                'extended-properties:Manager', 'extended-properties:manager'],
+            'company' => ['Company', 'meta:company', 'meta:Company', 'custom:Company', 'custom:company',
+                'extended-properties:Company', 'extended-properties:company']
+        ];
+    }
+}

--- a/classes/tika_helper.php
+++ b/classes/tika_helper.php
@@ -1,0 +1,564 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Helper class for metadataextrator_tika.
+ *
+ * Contains common functions used for extraction of metadata by subplugin and
+ * constant definitions.
+ *
+ * @package    metadataextractor_tika
+ * @copyright  2019 Tom Dickman <tomdickman@catalyst-au.net>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace metadataextractor_tika;
+
+defined('MOODLE_INTERNAL') || die();
+
+global $CFG;
+require_once($CFG->dirroot . '/admin/tool/metadata/constants.php');
+
+/**
+ * Helper class for metadataextrator_tika.
+ *
+ * @package    metadataextractor_tika
+ * @copyright  2019 Tom Dickman <tomdickman@catalyst-au.net>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class tika_helper {
+
+    /**
+     * File type - portable document format.
+     */
+    const FILETYPE_PDF = 'pdf';
+
+    /**
+     * File type - text document.
+     */
+    const FILETYPE_DOCUMENT = 'document';
+
+    /**
+     * File type - presentation (PowerPoint or similar).
+     */
+    const FILETYPE_PRESENTATION = 'presentation';
+
+    /**
+     * File type - presentation (PowerPoint or similar).
+     */
+    const FILETYPE_ARCHIVE = 'archive';
+
+    /**
+     * File type - spreadsheet (Excel or similar).
+     */
+    const FILETYPE_SPREADSHEET = 'spreadsheet';
+
+    /**
+     * File type - image (multiple formats).
+     */
+    const FILETYPE_IMAGE = 'image';
+
+    /**
+     * File type - image (multiple formats).
+     */
+    const FILETYPE_VIDEO = 'video';
+
+    /**
+     * File type - image (multiple formats).
+     */
+    const FILETYPE_AUDIO = 'audio';
+
+    /**
+     * File type - mock for testing only.
+     */
+    const FILETYPE_MOCK = 'mock';
+
+    /**
+     * File type - could not be determined.
+     */
+    const FILETYPE_OTHER = 'other';
+
+    /**
+     * Metadata type - An aggregation of resources.
+     */
+    const DCMI_TYPE_COLLECTION = 'collection';
+
+    /**
+     * Metadata type - Data encoded in a defined structure.
+     */
+    const DCMI_TYPE_DATASET = 'dataset';
+
+    /**
+     * Metadata type - A non-persistent, time-based occurrence.
+     */
+    const DCMI_TYPE_EVENT = 'event';
+
+    /**
+     * Metadata type - A resource requiring interaction from the user to be understood, executed, or experienced.
+     */
+    const DCMI_TYPE_INTERACTIVE = 'interactiveresource';
+
+    /**
+     * Metadata type - A visual representation other than text.
+     */
+    const DCMI_TYPE_IMAGE = 'image';
+
+    /**
+     * Metadata type - A series of visual representations imparting an impression of motion when shown in succession.
+     */
+    const DCMI_TYPE_MOVINGIMAGE = 'movingimage';
+
+    /**
+     * Metadata type - An inanimate, three-dimensional object or substance.
+     */
+    const DCMI_TYPE_PHYSICAL = 'physicalobject';
+
+    /**
+     * Metadata type - A system that provides one or more functions.
+     */
+    const DCMI_TYPE_SERVICE = 'service';
+
+    /**
+     * Metadata type - A computer program in source or compiled form.
+     */
+    const DCMI_TYPE_SOFTWARE = 'software';
+
+    /**
+     * Metadata type - A resource primarily intended to be heard.
+     */
+    const DCMI_TYPE_SOUND = 'sound';
+
+    /**
+     * Metadata type - A static visual representation.
+     */
+    const DCMI_TYPE_STILLIMAGE = 'stillimage';
+
+    /**
+     * Metadata type - A resource consisting primarily of words for reading.
+     */
+    const DCMI_TYPE_TEXT = 'text';
+
+    /**
+     * A map of the mimetype groups to DCMI types.
+     */
+    const DCMI_TYPE_MIMETYPE_GROUP_MAP = [
+        self::DCMI_TYPE_MOVINGIMAGE => ['video', 'html_video', 'web_video'],
+        self::DCMI_TYPE_SOUND => ['audio', 'html_audio', 'web_audio', 'html_track'],
+        self::DCMI_TYPE_IMAGE => ['image', 'web_image'],
+        self::DCMI_TYPE_COLLECTION => ['archive'],
+        self::DCMI_TYPE_TEXT => ['pdf', 'web_file', 'document', 'spreadsheet', 'presentation'],
+    ];
+
+    /**
+     * Mapping of tika_helper filetypes to tika supported mimetypes.
+     */
+    const FILETYPE_MIMETYPE_MAP = [
+        self::FILETYPE_PDF => [
+            'application/pdf'
+        ],
+        self::FILETYPE_DOCUMENT => [
+            'application/msword',
+            'application/vnd.oasis.opendocument.text',
+            'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+            'application/x-abiword'
+        ],
+        self::FILETYPE_PRESENTATION => [
+            'application/vnd.ms-powerpoint',
+            'application/vnd.oasis.opendocument.presentation',
+            'application/vnd.openxmlformats-officedocument.presentationml.presentation'
+        ],
+        self::FILETYPE_SPREADSHEET => [
+            'text/csv',
+            'application/vnd.ms-excel',
+            'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+            'application/vnd.oasis.opendocument.spreadsheet',
+        ],
+        self::FILETYPE_IMAGE => [
+            'image/aces',
+            'image/bmp',
+            'image/cgm',
+            'image/emf',
+            'image/example',
+            'image/fits',
+            'image/g3fax',
+            'image/gif',
+            'image/icns',
+            'image/ief',
+            'image/jp2',
+            'image/jpeg',
+            'image/jpm',
+            'image/jpx',
+            'image/naplps',
+            'image/nitf',
+            'image/png',
+            'image/prs.btif',
+            'image/prs.pti',
+            'image/svg+xml',
+            'image/t38',
+            'image/tiff',
+            'image/tiff-fx',
+            'image/vnd.adobe.photoshop',
+            'image/vnd.adobe.premiere',
+            'image/vnd.cns.inf2',
+            'image/vnd.djvu',
+            'image/vnd.dwg',
+            'image/vnd.dxb',
+            'image/vnd.dxf',
+            'image/vnd.dxf; format=ascii',
+            'image/vnd.dxf; format=binary',
+            'image/vnd.fastbidsheet',
+            'image/vnd.fpx',
+            'image/vnd.fst',
+            'image/vnd.fujixerox.edmics-mmr',
+            'image/vnd.fujixerox.edmics-rlc',
+            'image/vnd.globalgraphics.pgb',
+            'image/vnd.microsoft.icon',
+            'image/vnd.mix',
+            'image/vnd.ms-modi',
+            'image/vnd.net-fpx',
+            'image/vnd.radiance',
+            'image/vnd.sealed.png',
+            'image/vnd.sealedmedia.softseal.gif',
+            'image/vnd.sealedmedia.softseal.jpg',
+            'image/vnd.svf',
+            'image/vnd.wap.wbmp',
+            'image/vnd.xiff',
+            'image/vnd.zbrush.dcx',
+            'image/vnd.zbrush.pcx',
+            'image/webp',
+            'image/wmf',
+            'image/x-bpg',
+            'image/x-cmu-raster',
+            'image/x-cmx',
+            'image/x-dpx',
+            'image/x-emf-compressed',
+            'image/x-freehand',
+            'image/x-jbig2',
+            'image/x-jp2-codestream',
+            'image/x-jp2-container',
+            'image/x-niff',
+            'image/x-pict',
+            'image/x-portable-anymap',
+            'image/x-portable-bitmap',
+            'image/x-portable-graymap',
+            'image/x-portable-pixmap',
+            'image/x-raw-adobe',
+            'image/x-raw-canon',
+            'image/x-raw-casio',
+            'image/x-raw-epson',
+            'image/x-raw-fuji',
+            'image/x-raw-hasselblad',
+            'image/x-raw-imacon',
+            'image/x-raw-kodak',
+            'image/x-raw-leaf',
+            'image/x-raw-logitech',
+            'image/x-raw-mamiya',
+            'image/x-raw-minolta',
+            'image/x-raw-nikon',
+            'image/x-raw-olympus',
+            'image/x-raw-panasonic',
+            'image/x-raw-pentax',
+            'image/x-raw-phaseone',
+            'image/x-raw-rawzor',
+            'image/x-raw-red',
+            'image/x-raw-sigma',
+            'image/x-raw-sony',
+            'image/x-rgb',
+            'image/x-tga',
+            'image/x-xbitmap',
+            'image/x-xcf',
+            'image/x-xpixmap',
+            'image/x-xwindowdump'
+        ],
+        self::FILETYPE_VIDEO => [
+            'video/3gpp',
+            'video/3gpp-tt',
+            'video/3gpp2',
+            'video/bmpeg',
+            'video/bt656',
+            'video/celb',
+            'video/daala',
+            'video/dv',
+            'video/example',
+            'video/h261',
+            'video/h263',
+            'video/h263-1998',
+            'video/h263-2000',
+            'video/h264',
+            'video/jpeg',
+            'video/jpeg2000',
+            'video/mj2',
+            'video/mp1s',
+            'video/mp2p',
+            'video/mp2t',
+            'video/mp4',
+            'video/mp4v-es',
+            'video/mpeg',
+            'video/mpeg4-generic',
+            'video/mpv',
+            'video/nv',
+            'video/ogg',
+            'video/parityfec',
+            'video/pointer',
+            'video/quicktime',
+            'video/raw',
+            'video/rtp-enc-aescm128',
+            'video/rtx',
+            'video/smpte292m',
+            'video/theora',
+            'video/ulpfec',
+            'video/vc1',
+            'video/vnd.cctv',
+            'video/vnd.dlna.mpeg-tts',
+            'video/vnd.fvt',
+            'video/vnd.hns.video',
+            'video/vnd.iptvforum.1dparityfec-1010',
+            'video/vnd.iptvforum.1dparityfec-2005',
+            'video/vnd.iptvforum.2dparityfec-1010',
+            'video/vnd.iptvforum.2dparityfec-2005',
+            'video/vnd.iptvforum.ttsavc',
+            'video/vnd.iptvforum.ttsmpeg2',
+            'video/vnd.motorola.video',
+            'video/vnd.motorola.videop',
+            'video/vnd.mpegurl',
+            'video/vnd.ms-playready.media.pyv',
+            'video/vnd.nokia.interleaved-multimedia',
+            'video/vnd.nokia.videovoip',
+            'video/vnd.objectvideo',
+            'video/vnd.sealed.mpeg1',
+            'video/vnd.sealed.mpeg4',
+            'video/vnd.sealed.swf',
+            'video/vnd.sealedmedia.softseal.mov',
+            'video/vnd.vivo',
+            'video/webm',
+            'video/x-dirac',
+            'video/x-f4v',
+            'video/x-flc',
+            'video/x-fli',
+            'video/x-flv',
+            'video/x-jng',
+            'video/x-m4v',
+            'video/x-matroska',
+            'video/x-mng',
+            'video/x-ms-asf',
+            'video/x-ms-wm',
+            'video/x-ms-wmv',
+            'video/x-ms-wmx',
+            'video/x-ms-wvx',
+            'video/x-msvideo',
+            'video/x-oggrgb',
+            'video/x-ogguvs',
+            'video/x-oggyuv',
+            'video/x-ogm',
+            'video/x-sgi-movie'
+        ],
+        self::FILETYPE_AUDIO => [
+            'audio/3gpp',
+            'audio/3gpp2',
+            'audio/ac3',
+            'audio/adpcm',
+            'audio/amr',
+            'audio/amr-wb',
+            'audio/amr-wb+',
+            'audio/asc',
+            'audio/basic',
+            'audio/bv16',
+            'audio/bv32',
+            'audio/clearmode',
+            'audio/cn',
+            'audio/dat12',
+            'audio/dls',
+            'audio/dsr-es201108',
+            'audio/dsr-es202050',
+            'audio/dsr-es202211',
+            'audio/dsr-es202212',
+            'audio/dvi4',
+            'audio/eac3',
+            'audio/evrc',
+            'audio/evrc-qcp',
+            'audio/evrc0',
+            'audio/evrc1',
+            'audio/evrcb',
+            'audio/evrcb0',
+            'audio/evrcb1',
+            'audio/evrcwb',
+            'audio/evrcwb0',
+            'audio/evrcwb1',
+            'audio/example',
+            'audio/g719',
+            'audio/g722',
+            'audio/g7221',
+            'audio/g723',
+            'audio/g726-16',
+            'audio/g726-24',
+            'audio/g726-32',
+            'audio/g726-40',
+            'audio/g728',
+            'audio/g729',
+            'audio/g7291',
+            'audio/g729d',
+            'audio/g729e',
+            'audio/gsm',
+            'audio/gsm-efr',
+            'audio/ilbc',
+            'audio/l16',
+            'audio/l20',
+            'audio/l24',
+            'audio/l8',
+            'audio/lpc',
+            'audio/midi',
+            'audio/mobile-xmf',
+            'audio/mp4',
+            'audio/mp4a-latm',
+            'audio/mpa',
+            'audio/mpa-robust',
+            'audio/mpeg',
+            'audio/mpeg4-generic',
+            'audio/ogg',
+            'audio/opus',
+            'audio/parityfec',
+            'audio/pcma',
+            'audio/pcma-wb',
+            'audio/pcmu',
+            'audio/pcmu-wb',
+            'audio/prs.sid',
+            'audio/qcelp',
+            'audio/red',
+            'audio/rtp-enc-aescm128',
+            'audio/rtp-midi',
+            'audio/rtx',
+            'audio/smv',
+            'audio/smv-qcp',
+            'audio/smv0',
+            'audio/sp-midi',
+            'audio/speex',
+            'audio/t140c',
+            'audio/t38',
+            'audio/telephone-event',
+            'audio/tone',
+            'audio/ulpfec',
+            'audio/vdvi',
+            'audio/vmr-wb',
+            'audio/vnd.3gpp.iufp',
+            'audio/vnd.4sb',
+            'audio/vnd.adobe.soundbooth',
+            'audio/vnd.audiokoz',
+            'audio/vnd.celp',
+            'audio/vnd.cisco.nse',
+            'audio/vnd.cmles.radio-events',
+            'audio/vnd.cns.anp1',
+            'audio/vnd.cns.inf1',
+            'audio/vnd.digital-winds',
+            'audio/vnd.dlna.adts',
+            'audio/vnd.dolby.heaac.1',
+            'audio/vnd.dolby.heaac.2',
+            'audio/vnd.dolby.mlp',
+            'audio/vnd.dolby.mps',
+            'audio/vnd.dolby.pl2',
+            'audio/vnd.dolby.pl2x',
+            'audio/vnd.dolby.pl2z',
+            'audio/vnd.dts',
+            'audio/vnd.dts.hd',
+            'audio/vnd.everad.plj',
+            'audio/vnd.hns.audio',
+            'audio/vnd.lucent.voice',
+            'audio/vnd.ms-playready.media.pya',
+            'audio/vnd.nokia.mobile-xmf',
+            'audio/vnd.nortel.vbk',
+            'audio/vnd.nuera.ecelp4800',
+            'audio/vnd.nuera.ecelp7470',
+            'audio/vnd.nuera.ecelp9600',
+            'audio/vnd.octel.sbc',
+            'audio/vnd.qcelp',
+            'audio/vnd.rhetorex.32kadpcm',
+            'audio/vnd.sealedmedia.softseal.mpeg',
+            'audio/vnd.vmx.cvsd',
+            'audio/vnd.wave',
+            'audio/vorbis',
+            'audio/vorbis-config',
+            'audio/x-aac',
+            'audio/x-adpcm',
+            'audio/x-aiff',
+            'audio/x-caf',
+            'audio/x-dec-adpcm',
+            'audio/x-dec-basic',
+            'audio/x-flac',
+            'audio/x-matroska',
+            'audio/x-mod',
+            'audio/x-mpegurl',
+            'audio/x-ms-wax',
+            'audio/x-ms-wma',
+            'audio/x-oggflac',
+            'audio/x-oggpcm',
+            'audio/x-pn-realaudio',
+            'audio/x-pn-realaudio-plugin'
+        ],
+        self::FILETYPE_ARCHIVE => [
+            'application/x-freearc',
+            'application/x-bzip',
+            'application/x-bzip2',
+            'application/gzip',
+            'application/x-tar',
+            'application/zip',
+            'application/x-7z-compressed'
+        ]
+    ];
+
+
+    /**
+     * Get the filetype based on mimetype.
+     *
+     * @param string $mimetype the mimetype of file.
+     *
+     * @return string constant file type.
+     */
+    public static function get_filetype(string $mimetype) {
+        $filetype = self::FILETYPE_OTHER;
+
+        foreach (self::FILETYPE_MIMETYPE_MAP as $mappedfiletype => $mappedmimetypes) {
+            foreach ($mappedmimetypes as $mappedmimetype) {
+                if ($mimetype == $mappedmimetype) {
+                    // We found our filetype, end here.
+                    $filetype = $mappedfiletype;
+                    break;
+                }
+            }
+        }
+
+        return $filetype;
+    }
+
+    /**
+     * Get the metadata class to instantiate based on the mimetype of
+     * Tika returned metadata.
+     *
+     * @param string $mimetype
+     *
+     * @return string
+     */
+    public static function get_metadata_class(string $mimetype) {
+        $filetype = self::get_filetype($mimetype);
+
+        // TODO: Add support for all file types.
+        if ($filetype == self::FILETYPE_DOCUMENT) {
+            $class = '\metadataextractor_tika\metadata_' . self::FILETYPE_DOCUMENT;
+        } else {
+            $class = '\metadataextractor_tika\metadata';
+        }
+
+        return $class;
+    }
+}

--- a/cli/server_extract.php
+++ b/cli/server_extract.php
@@ -1,4 +1,26 @@
 <?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Tika server raw metadata CLI extractor.
+ *
+ * @package    tool_metadata
+ * @copyright  2020 Tom Dickman <tomdickman@catalyst-au.net>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
 
 define('CLI_SCRIPT', true);
 

--- a/cli/server_extract.php
+++ b/cli/server_extract.php
@@ -1,0 +1,104 @@
+<?php
+
+define('CLI_SCRIPT', true);
+
+require_once(__DIR__ . '/../../../../../../config.php');
+require_once($CFG->libdir . '/adminlib.php');
+require_once($CFG->libdir . '/clilib.php');
+
+list($options, $unrecognized) = cli_get_params(
+    [
+        'host' => 'localhost',
+        'port' => 0,
+        'fileid' => 0,
+        'help' => false,
+        'showdebugging' => false,
+        'json' => false
+    ], [
+        'f' => 'fileid',
+        'h' => 'help',
+        'j' => 'json'
+    ]
+);
+
+if ($unrecognized) {
+    $unrecognized = implode("\n  ", $unrecognized);
+    cli_error(get_string('cliunknowoption', 'admin', $unrecognized));
+}
+
+if ($options['help']) {
+    mtrace(
+<<<HELP
+Extract json metadata from a file using a remote tika server using RESTful API.
+
+Options:
+-h, --help               Print out this help
+-f --fileid (required)   The file id of the Moodle instance file to extract metadata for
+--showdebugging          Print debugging statements
+-j --json                Print metadata as a raw json string
+--host (optional)        Set the hostname or IP address of the tika server. 
+                         WARNING: This will change the plugin configured host
+--port (optional)        Set the port number on the host where tika server API is exposed
+                         WARNING: This will change the plugin configured port number 
+
+Example:
+\$ php admin/tool/metadata/extractor/tika/cli/server_extract.php -f=10999
+HELP
+    );
+    exit(0);
+}
+
+if ($options['showdebugging']) {
+    set_debugging(DEBUG_DEVELOPER, true);
+}
+
+$host = get_config('metadataextractor_tika', 'tikaserverhost');
+$port = get_config('metadataextractor_tika', 'tikaserverport');
+
+if (!empty($options['host'])) {
+    set_config('tikaserverhost', $options['host'], 'metadataextractor_tika');
+    $host = $options['host'];
+} elseif (empty($host)) {
+    mtrace('No host name set for tika server, pass in host value or set host in plugin settings.');
+    exit(1);
+}
+
+if (!empty($options['port'])) {
+    set_config('tikaserverport', $options['port'], 'metadataextractor_tika');
+    $port = $options['port'];
+} elseif (empty($port)) {
+    mtrace('No port value set for tika server, pass in port number or set port number in plugin settings.');
+    exit(1);
+}
+
+if (empty($options['fileid'])) {
+    mtrace('No file id value, you must pass in the id of a file to extract metadata for.');
+    exit(1);
+} elseif (!is_number($options['fileid'])) {
+    mtrace('File id must be a number.');
+    exit(1);
+} else {
+    $fs = get_file_storage();
+    $file = $fs->get_file_by_id($options['fileid']);
+}
+
+if(empty($file)) {
+    mtrace('No file found with id=' . $options['fileid'] . ' in Moodle instance.');
+    exit(1);
+}
+
+$server = new \metadataextractor_tika\server();
+
+if (!$server->is_ready()) {
+    mtrace('Could not connect to server at ' . $host . ':' . $port);
+    exit(1);
+}
+
+$jsonmetadata = $server->get_file_metadata($file);
+$metadata = json_decode($jsonmetadata, true);
+if (empty($options['json'])) {
+    mtrace(var_dump($metadata));
+} else {
+    mtrace($jsonmetadata);
+}
+exit(0);

--- a/db/install.xml
+++ b/db/install.xml
@@ -27,5 +27,23 @@
         <KEY NAME="resourcehash" TYPE="unique" FIELDS="resourcehash"/>
       </KEYS>
     </TABLE>
+    <TABLE NAME="tika_document_metadata" COMMENT="Supplementary table for tika metadata extracted from document file types">
+      <FIELDS>
+        <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
+        <FIELD NAME="resourcehash" TYPE="char" LENGTH="40" NOTNULL="true" SEQUENCE="false"/>
+        <FIELD NAME="pagecount" TYPE="int" LENGTH="10" NOTNULL="false" SEQUENCE="false"/>
+        <FIELD NAME="paragraphcount" TYPE="int" LENGTH="10" NOTNULL="false" SEQUENCE="false"/>
+        <FIELD NAME="linecount" TYPE="int" LENGTH="10" NOTNULL="false" SEQUENCE="false"/>
+        <FIELD NAME="wordcount" TYPE="int" LENGTH="10" NOTNULL="false" SEQUENCE="false"/>
+        <FIELD NAME="charactercount" TYPE="int" LENGTH="10" NOTNULL="false" SEQUENCE="false"/>
+        <FIELD NAME="charactercountwithspaces" TYPE="int" LENGTH="10" NOTNULL="false" SEQUENCE="false"/>
+        <FIELD NAME="manager" TYPE="char" LENGTH="500" NOTNULL="false" SEQUENCE="false"/>
+        <FIELD NAME="company" TYPE="char" LENGTH="500" NOTNULL="false" SEQUENCE="false"/>
+      </FIELDS>
+      <KEYS>
+        <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
+        <KEY NAME="resourcehash" TYPE="unique" FIELDS="resourcehash"/>
+      </KEYS>
+    </TABLE>
   </TABLES>
 </XMLDB>

--- a/db/install.xml
+++ b/db/install.xml
@@ -11,7 +11,7 @@
         <FIELD NAME="format" TYPE="char" LENGTH="255" NOTNULL="false" SEQUENCE="false" COMMENT="The MIME type of the resource, in accordance with IANA Media Types."/>
         <FIELD NAME="type" TYPE="char" LENGTH="40" NOTNULL="false" SEQUENCE="false" COMMENT="One of the Dublin Core Metadata Initiative Type Vocabulary types."/>
         <FIELD NAME="description" TYPE="text" NOTNULL="false" SEQUENCE="false"/>
-        <FIELD NAME="title" TYPE="char" LENGTH="255" NOTNULL="false" SEQUENCE="false" COMMENT="The name given to the resource, usually by the creator or publisher."/>
+        <FIELD NAME="title" TYPE="char" LENGTH="1000" NOTNULL="false" SEQUENCE="false" COMMENT="The name given to the resource, usually by the creator or publisher."/>
         <FIELD NAME="subject" TYPE="text" NOTNULL="false" SEQUENCE="false" COMMENT="The topic of the resource.  Typically, subject will be expressed as keywords or phrases that describe the subject or content of the resource."/>
         <FIELD NAME="creator" TYPE="char" LENGTH="100" NOTNULL="false" SEQUENCE="false" COMMENT="The person or organization primarily responsible for creating the intellectual content of the resource this metadata represents."/>
         <FIELD NAME="contributor" TYPE="text" NOTNULL="false" SEQUENCE="false" COMMENT="Persons or organizations not specified in the creator who have made significant intellectual contributions to the resource but whose contribution is secondary to any person or organization specified in creator."/>

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -55,5 +55,17 @@ function xmldb_metadataextractor_tika_upgrade($oldversion) {
         upgrade_plugin_savepoint(true, 2020020600, 'metadataextractor', 'tika');
     }
 
+    if ($oldversion < 2020030201) {
+        $table = new xmldb_table('metadataextractor_tika');
+        // Lenghten field title on table metadataextractor_tika.
+        $field = new xmldb_field('title', XMLDB_TYPE_CHAR, '1000', null, null, null, null, 'description');
+
+        // Launch change field type title.
+        $dbman->change_field_type($table, $field);
+
+        // Tika savepoint reached.
+        upgrade_plugin_savepoint(true, 2020030201, 'metadataextractor', 'tika');
+    }
+
     return true;
 }

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -18,7 +18,7 @@
  * Upgrade database for metadataextractor_tika.
  *
  * @package    tool_metadata
- * @copyright  2019 Tom Dickman <tomdickman@catalyst-au.net>
+ * @copyright  2020 Tom Dickman <tomdickman@catalyst-au.net>
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
@@ -65,6 +65,36 @@ function xmldb_metadataextractor_tika_upgrade($oldversion) {
 
         // Tika savepoint reached.
         upgrade_plugin_savepoint(true, 2020030201, 'metadataextractor', 'tika');
+    }
+
+    if ($oldversion < 2020031101) {
+
+        // Define table tika_document to be created.
+        $table = new xmldb_table('tika_document_metadata');
+
+        // Adding fields to table tika_document_metadata.
+        $table->add_field('id', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, XMLDB_SEQUENCE, null);
+        $table->add_field('resourcehash', XMLDB_TYPE_CHAR, '40', null, XMLDB_NOTNULL, null, null);
+        $table->add_field('pagecount', XMLDB_TYPE_INTEGER, '10', null, null, null, null);
+        $table->add_field('paragraphcount', XMLDB_TYPE_INTEGER, '10', null, null, null, null);
+        $table->add_field('linecount', XMLDB_TYPE_INTEGER, '10', null, null, null, null);
+        $table->add_field('wordcount', XMLDB_TYPE_INTEGER, '10', null, null, null, null);
+        $table->add_field('charactercount', XMLDB_TYPE_INTEGER, '10', null, null, null, null);
+        $table->add_field('charactercountwithspaces', XMLDB_TYPE_INTEGER, '10', null, null, null, null);
+        $table->add_field('manager', XMLDB_TYPE_CHAR, '500', null, null, null, null);
+        $table->add_field('company', XMLDB_TYPE_CHAR, '500', null, null, null, null);
+
+        // Adding keys to table tika_document_metadata.
+        $table->add_key('primary', XMLDB_KEY_PRIMARY, ['id']);
+        $table->add_key('resourcehash', XMLDB_KEY_UNIQUE, ['resourcehash']);
+
+        // Conditionally launch create table for tika_document_metadata.
+        if (!$dbman->table_exists($table)) {
+            $dbman->create_table($table);
+        }
+
+        // Tika savepoint reached.
+        upgrade_plugin_savepoint(true, 2020031101, 'metadataextractor', 'tika');
     }
 
     return true;

--- a/tests/extractor_test.php
+++ b/tests/extractor_test.php
@@ -71,9 +71,8 @@ class extractor_test extends advanced_testcase {
      * Test extracting metadata for a pdf file resource in Moodle.
      */
     public function test_extract_file_metadata_pdf() {
-        global $CFG;
 
-        $file = mock_file_builder::mock_pdf();
+        [$metadata, $file] = mock_file_builder::mock_pdf();
         $extractor = new extractor();
 
         // Make sure we have the correct configuration and dependencies to carry out this test.
@@ -82,8 +81,8 @@ class extractor_test extends advanced_testcase {
         $result = $extractor->extract_file_metadata($file);
 
         $this->assertNotEmpty($result);
-        $this->assertEquals('Moodle ' . $CFG->release, $result->creator);
-        $this->assertEquals('Test PDF', $result->title);
+        $this->assertEquals($metadata['Creator'], $result->creator);
+        $this->assertEquals($metadata['Title'], $result->title);
         $this->assertEquals('en', $result->language);
     }
 

--- a/tests/extractor_test.php
+++ b/tests/extractor_test.php
@@ -22,11 +22,10 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 use metadataextractor_tika\extractor;
-use tool_metadata\mock_file_builder;
 
 defined('MOODLE_INTERNAL') || die();
 
-
+require_once (__DIR__ . '/../../../classes/mock_file_builder.php');
 
 /**
  * Unit tests for tool_metadata extractor class.
@@ -36,7 +35,7 @@ defined('MOODLE_INTERNAL') || die();
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  * @group      metadataextractor_tika
  */
-class extractor_test extends advanced_testcase {
+class metadataextractor_tika_extractor_test extends advanced_testcase {
 
     public function setUp() {
         $this->resetAfterTest();
@@ -72,7 +71,7 @@ class extractor_test extends advanced_testcase {
      */
     public function test_extract_file_metadata_pdf() {
 
-        [$metadata, $file] = mock_file_builder::mock_pdf();
+        [$metadata, $file] = \tool_metadata\mock_file_builder::mock_pdf();
         $extractor = new extractor();
 
         // Make sure we have the correct configuration and dependencies to carry out this test.
@@ -84,6 +83,24 @@ class extractor_test extends advanced_testcase {
         $this->assertEquals($metadata['Creator'], $result->creator);
         $this->assertEquals($metadata['Title'], $result->title);
         $this->assertEquals('en', $result->language);
+    }
+
+    /**
+     * Test extracting metadata for a document type file resource.
+     */
+    public function test_extract_file_metadata_document() {
+        list($expectedmetadata, $file) = \tool_metadata\mock_file_builder::mock_document();
+
+        $extractor = new extractor();
+
+        // Make sure we have the correct configuration and dependencies to carry out this test.
+        $this->can_test_extraction($extractor);
+
+        $result = $extractor->extract_file_metadata($file);
+
+        $this->assertNotEmpty($result);
+        $this->assertInstanceOf(\metadataextractor_tika\metadata_document::class, $result);
+        $this->assertEquals($expectedmetadata['Title'], $result->title);
     }
 
     /**

--- a/tests/metadata_mock.php
+++ b/tests/metadata_mock.php
@@ -1,0 +1,51 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Mock metadataextractor_tika metadata subclass.
+ *
+ * @package    tool_metadata
+ * @copyright  2020 Tom Dickman <tomdickman@catalyst-au.net>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @group      tool_metadata
+ */
+
+namespace metadataextractor_tika;
+
+defined('MOODLE_INTERNAL') || die();
+
+/**
+ * Mock metadataextractor_tika metadata subclass.
+ *
+ * @package    metadataextractor_tika
+ * @copyright  2020 Tom Dickman <tomdickman@catalyst-au.net>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class metadata_mock extends \metadataextractor_tika\metadata {
+
+    public $wordcount;
+
+    public $pagecount;
+
+    public const SUPPLEMENTARY_TABLE = 'metadataextractor_tika_mock';
+
+    protected function supplementary_key_map() {
+        return [
+            'wordcount' => ['Word-Count', 'meta:word-count'],
+            'pagecount' => ['Page-Count', 'meta:page-count', 'xmpTPg:NPages'],
+        ];
+    }
+}

--- a/tests/metadata_test.php
+++ b/tests/metadata_test.php
@@ -1,0 +1,376 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * metadataextractor_tika metadata tests.
+ *
+ * @package    metadataextractor_tika
+ * @copyright  2020 Tom Dickman <tomdickman@catalyst-au.net>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') || die();
+
+global $CFG;
+require_once($CFG->dirroot . '/admin/tool/metadata/constants.php');
+require_once(__DIR__ . '/metadata_mock.php');
+
+/**
+ * metadataextractor_tika metadata tests.
+ *
+ * @package    metadataextractor_tika
+ * @copyright  2020 Tom Dickman <tomdickman@catalyst-au.net>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @group      metadataextractor_tika
+ */
+class metadataextractor_tika_metadata_testcase extends advanced_testcase {
+
+    public function setUp() {
+        global $DB;
+
+        $this->resetAfterTest();
+
+        // Create a table for mock metadata subclass.
+        $dbman = $DB->get_manager();
+        $table = new \xmldb_table(\metadataextractor_tika\metadata_mock::SUPPLEMENTARY_TABLE);
+        // Add mandatory fields.
+        $table->add_field('id', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, XMLDB_SEQUENCE, null);
+        $table->add_field('resourcehash', XMLDB_TYPE_CHAR, '40', null, XMLDB_NOTNULL, null, null, 'id');
+        // Add the fields used in metadata subclass.
+        $table->add_field('wordcount', XMLDB_TYPE_INTEGER, '10', null, null, null, null, 'resourcehash');
+        $table->add_field('pagecount', XMLDB_TYPE_INTEGER, '5', null, null, null, null, 'wordcount');
+
+        $table->add_key('primary', XMLDB_KEY_PRIMARY, array('id'));
+
+        $dbman->create_table($table);
+    }
+
+    public function tearDown() {
+        global $DB;
+
+        $dbman = $DB->get_manager();
+        $table = new \xmldb_table(\metadataextractor_tika\metadata_mock::SUPPLEMENTARY_TABLE);
+        $dbman->drop_table($table);
+    }
+
+    public function test_get_supplementary_table() {
+
+        // Emulate tika extracted raw metadata.
+        $rawdata = [];
+        // Fixed tika fields.
+        $rawdata['meta:creator'] = 'Moodle';
+        $rawdata['meta:title'] = 'Test title';
+        // Supplementary fields.
+        $rawdata['meta:word-count'] = 3000;
+        $rawdata['meta:page-count'] = 3;
+
+        // Emulate resourcehash from resource content.
+        $resourcehash = sha1(random_string());
+
+        $metadata = new \metadataextractor_tika\metadata_mock(0, $resourcehash, $rawdata);
+        $actual = $metadata->get_supplementary_table();
+
+        $this->assertEquals(\metadataextractor_tika\metadata_mock::SUPPLEMENTARY_TABLE, $actual);
+    }
+
+    public function test_has_supplementary_data() {
+
+        // Emulate tika extracted raw metadata.
+        $rawdata = [];
+        // Fixed tika fields.
+        $rawdata['meta:creator'] = 'Moodle';
+        $rawdata['meta:title'] = 'Test title';
+        // Supplementary fields.
+        $rawdata['meta:word-count'] = 3000;
+        $rawdata['meta:page-count'] = 3;
+
+        // Emulate resourcehash from resource content.
+        $resourcehash = sha1(random_string());
+
+        // Extending classes may have supplementary data.
+        $metadata = new \metadataextractor_tika\metadata_mock(0, $resourcehash, $rawdata);
+        $this->assertTrue($metadata->has_supplementary_data());
+
+        // Base class does not have supplementary data.
+        $metadata = new \metadataextractor_tika\metadata(0, $resourcehash, $rawdata);
+        $this->assertFalse($metadata->has_supplementary_data());
+    }
+
+    public function test_get_record() {
+
+        // Emulate tika extracted raw metadata.
+        $rawdata = [];
+        // Fixed tika fields.
+        $rawdata['meta:creator'] = 'Moodle';
+        $rawdata['meta:title'] = 'Test title';
+        // Supplementary fields.
+        $rawdata['meta:word-count'] = 3000;
+        $rawdata['meta:page-count'] = 3;
+
+        // Emulate resourcehash from resource content.
+        $resourcehash = sha1(random_string());
+
+        $metadata = new \metadataextractor_tika\metadata_mock(0, $resourcehash, $rawdata);
+
+        $actual = $metadata->get_record();
+
+        $this->assertEquals($metadata->id, $actual->id);
+        $this->assertEquals($resourcehash, $actual->resourcehash);
+        $this->assertEquals($rawdata['meta:creator'], $actual->creator);
+        $this->assertEquals($rawdata['meta:title'], $actual->title);
+        $this->assertEquals($rawdata['meta:word-count'], $actual->wordcount);
+        $this->assertEquals($rawdata['meta:page-count'], $actual->pagecount);
+    }
+
+    public function test_populate_from_id() {
+        global $DB;
+
+        // Emulate tika extracted raw metadata.
+        $rawdata = [];
+        // Fixed tika fields.
+        $rawdata['meta:creator'] = 'Moodle';
+        $rawdata['meta:title'] = 'Test title';
+        // Supplementary fields.
+        $rawdata['meta:word-count'] = 3000;
+        $rawdata['meta:page-count'] = 3;
+
+        // Emulate resourcehash from resource content.
+        $resourcehash = sha1(random_string());
+
+        // Insert existing records for testing metadata population from existing records.
+        $id = $DB->insert_record(\metadataextractor_tika\metadata_mock::TABLE,
+            ['creator' => $rawdata['meta:creator'], 'title' => $rawdata['meta:title'], 'resourcehash' => $resourcehash]);
+        $DB->insert_record(\metadataextractor_tika\metadata_mock::SUPPLEMENTARY_TABLE,
+            [
+                'wordcount' =>  $rawdata['meta:word-count'],
+                'pagecount' => $rawdata['meta:page-count'],
+                'resourcehash' => $resourcehash,
+            ]);
+
+        $metadata = new \metadataextractor_tika\metadata_mock($id);
+
+        $this->assertInstanceOf(\metadataextractor_tika\metadata_mock::class, $metadata);
+        $this->assertEquals($id, $metadata->get('id'));
+        $this->assertEquals($resourcehash, $metadata->get_resourcehash());
+        $this->assertEquals($rawdata['meta:creator'], $metadata->get('creator'));
+        $this->assertEquals($rawdata['meta:title'], $metadata->get('title'));
+        $this->assertEquals($rawdata['meta:word-count'], $metadata->get('wordcount'));
+        $this->assertEquals($rawdata['meta:page-count'], $metadata->get('pagecount'));
+
+        $metadata = new \metadataextractor_tika\metadata($id);
+
+        $this->assertInstanceOf(\metadataextractor_tika\metadata::class, $metadata);
+        $this->assertEquals($id, $metadata->get('id'));
+        $this->assertEquals($resourcehash, $metadata->get_resourcehash());
+        $this->assertEquals($rawdata['meta:creator'], $metadata->get('creator'));
+        $this->assertEquals($rawdata['meta:title'], $metadata->get('title'));
+        $this->assertClassNotHasAttribute('wordcount', \metadataextractor_tika\metadata::class);
+        $this->assertClassNotHasAttribute('pagecount', \metadataextractor_tika\metadata::class);
+    }
+
+    public function test_populate_from_resourcehash() {
+        global $DB;
+
+        // Emulate tika extracted raw metadata.
+        $rawdata = [];
+        // Fixed tika fields.
+        $rawdata['meta:creator'] = 'Moodle';
+        $rawdata['meta:title'] = 'Test title';
+        // Supplementary fields.
+        $rawdata['meta:word-count'] = 3000;
+        $rawdata['meta:page-count'] = 3;
+
+        // Emulate resourcehash from resource content.
+        $resourcehash = sha1(random_string());
+
+        // Insert existing records for testing metadata population from existing records.
+        $id = $DB->insert_record(\metadataextractor_tika\metadata_mock::TABLE,
+            ['creator' => $rawdata['meta:creator'], 'title' => $rawdata['meta:title'], 'resourcehash' => $resourcehash]);
+        $DB->insert_record(\metadataextractor_tika\metadata_mock::SUPPLEMENTARY_TABLE,
+            [
+                'wordcount' =>  $rawdata['meta:word-count'],
+                'pagecount' => $rawdata['meta:page-count'],
+                'resourcehash' => $resourcehash,
+            ]);
+
+        $metadata = new \metadataextractor_tika\metadata_mock(0, $resourcehash);
+
+        $this->assertInstanceOf(\metadataextractor_tika\metadata_mock::class, $metadata);
+        $this->assertEquals($id, $metadata->get('id'));
+        $this->assertEquals($resourcehash, $metadata->get_resourcehash());
+        $this->assertEquals($rawdata['meta:creator'], $metadata->get('creator'));
+        $this->assertEquals($rawdata['meta:title'], $metadata->get('title'));
+        $this->assertEquals($rawdata['meta:word-count'], $metadata->get('wordcount'));
+        $this->assertEquals($rawdata['meta:page-count'], $metadata->get('pagecount'));
+
+        $metadata = new \metadataextractor_tika\metadata(0, $resourcehash);
+
+        $this->assertInstanceOf(\metadataextractor_tika\metadata::class, $metadata);
+        $this->assertEquals($id, $metadata->get('id'));
+        $this->assertEquals($resourcehash, $metadata->get_resourcehash());
+        $this->assertEquals($rawdata['meta:creator'], $metadata->get('creator'));
+        $this->assertEquals($rawdata['meta:title'], $metadata->get('title'));
+        $this->assertClassNotHasAttribute('wordcount', \metadataextractor_tika\metadata::class);
+        $this->assertClassNotHasAttribute('pagecount', \metadataextractor_tika\metadata::class);
+
+        $resourcehash = sha1(random_string());
+
+        $this->expectException(\tool_metadata\metadata_exception::class);
+        $unused = new \metadataextractor_tika\metadata_mock(0, $resourcehash);
+    }
+
+    public function test_populate_from_raw() {
+
+        // Emulate tika extracted raw metadata.
+        $rawdata = [];
+        // Fixed tika fields.
+        $rawdata['meta:creator'] = 'Moodle';
+        $rawdata['meta:title'] = 'Test title';
+        // Supplementary fields.
+        $rawdata['meta:word-count'] = 3000;
+        $rawdata['meta:page-count'] = 3;
+
+        // Emulate resourcehash from resource content.
+        $resourcehash = sha1(random_string());
+
+        $metadata = new \metadataextractor_tika\metadata_mock(0, $resourcehash, $rawdata);
+
+        $this->assertInstanceOf(\metadataextractor_tika\metadata_mock::class, $metadata);
+        $this->assertEquals(0, $metadata->get('id'));
+        $this->assertEquals($resourcehash, $metadata->get_resourcehash());
+        $this->assertEquals($rawdata['meta:creator'], $metadata->get('creator'));
+        $this->assertEquals($rawdata['meta:title'], $metadata->get('title'));
+        $this->assertEquals($rawdata['meta:word-count'], $metadata->get('wordcount'));
+        $this->assertEquals($rawdata['meta:page-count'], $metadata->get('pagecount'));
+
+        $metadata = new \metadataextractor_tika\metadata(0, $resourcehash, $rawdata);
+
+        $this->assertInstanceOf(\metadataextractor_tika\metadata::class, $metadata);
+        $this->assertEquals(0, $metadata->get('id'));
+        $this->assertEquals($resourcehash, $metadata->get_resourcehash());
+        $this->assertEquals($rawdata['meta:creator'], $metadata->get('creator'));
+        $this->assertEquals($rawdata['meta:title'], $metadata->get('title'));
+        $this->assertClassNotHasAttribute('wordcount', \metadataextractor_tika\metadata::class);
+        $this->assertClassNotHasAttribute('pagecount', \metadataextractor_tika\metadata::class);
+    }
+
+    public function test_create() {
+        global $DB;
+
+        // Emulate tika extracted raw metadata.
+        $rawdata = [];
+        // Fixed tika fields.
+        $rawdata['meta:creator'] = 'Moodle';
+        $rawdata['meta:title'] = 'Test title';
+        // Supplementary fields.
+        $rawdata['meta:word-count'] = 3000;
+        $rawdata['meta:page-count'] = 3;
+
+        // Emulate resourcehash from resource content.
+        $resourcehash = sha1(random_string());
+
+        $metadata = new \metadataextractor_tika\metadata_mock(0, $resourcehash, $rawdata);
+        $metadata->create();
+
+        // Metadata instance variable values should be correctly stored in database.
+        $baserecord = $DB->get_record(\metadataextractor_tika\metadata_mock::TABLE, ['id' => $metadata->id]);
+        $this->assertEquals($metadata->get_resourcehash(), $baserecord->resourcehash);
+        $this->assertEquals($metadata->get('creator'), $baserecord->creator);
+        $this->assertEquals($metadata->get('title'), $baserecord->title);
+        $supplementaryrecord = $DB->get_record(\metadataextractor_tika\metadata_mock::SUPPLEMENTARY_TABLE,
+            ['resourcehash' => $metadata->get_resourcehash()]);
+        $this->assertEquals($metadata->get_resourcehash(), $supplementaryrecord->resourcehash);
+        $this->assertEquals($metadata->get('wordcount'), $supplementaryrecord->wordcount);
+        $this->assertEquals($metadata->get('pagecount'), $supplementaryrecord->pagecount);
+
+        // Cannot create metadata records if record already exists.
+        $this->expectException(\tool_metadata\metadata_exception::class);
+        $metadata->create();
+    }
+
+    public function test_update() {
+        global $DB;
+
+        // Emulate tika extracted raw metadata.
+        $rawdata = [];
+        // Fixed tika fields.
+        $rawdata['meta:creator'] = 'Moodle';
+        $rawdata['meta:title'] = 'Test title';
+        // Supplementary fields.
+        $rawdata['meta:word-count'] = 3000;
+        $rawdata['meta:page-count'] = 3;
+
+        // Emulate resourcehash from resource content.
+        $resourcehash = sha1(random_string());
+
+        $metadata = new \metadataextractor_tika\metadata_mock(0, $resourcehash, $rawdata);
+        $metadata->create();
+
+        $id = $metadata->id;
+
+        // Update metadata.
+        $metadata->set('creator', 'Moodle 2.0');
+        $metadata->set('title', 'Updated title');
+        $metadata->set('wordcount', 4000);
+        $metadata->set('pagecount', 4);
+
+        $result = $metadata->update();
+
+        $this->assertTrue($result);
+
+        // Metadata instance variable values should be correctly stored in database.
+        $baserecord = $DB->get_record(\metadataextractor_tika\metadata_mock::TABLE, ['id' => $metadata->id]);
+        $this->assertEquals($metadata->get_resourcehash(), $baserecord->resourcehash);
+        $this->assertEquals($metadata->get('creator'), $baserecord->creator);
+        $this->assertEquals($metadata->get('title'), $baserecord->title);
+        $supplementaryrecord = $DB->get_record(\metadataextractor_tika\metadata_mock::SUPPLEMENTARY_TABLE,
+            ['resourcehash' => $metadata->get_resourcehash()]);
+        $this->assertEquals($metadata->get_resourcehash(), $supplementaryrecord->resourcehash);
+        $this->assertEquals($metadata->get('wordcount'), $supplementaryrecord->wordcount);
+        $this->assertEquals($metadata->get('pagecount'), $supplementaryrecord->pagecount);
+    }
+
+    public function test_delete() {
+        global $DB;
+
+        // Emulate tika extracted raw metadata.
+        $rawdata = [];
+        // Fixed tika fields.
+        $rawdata['meta:creator'] = 'Moodle';
+        $rawdata['meta:title'] = 'Test title';
+        // Supplementary fields.
+        $rawdata['meta:word-count'] = 3000;
+        $rawdata['meta:page-count'] = 3;
+
+        // Emulate resourcehash from resource content.
+        $resourcehash = sha1(random_string());
+
+        $metadata = new \metadataextractor_tika\metadata_mock(0, $resourcehash, $rawdata);
+        $metadata->create();
+
+        $id = $metadata->id;
+        $resourcehash = $metadata->get_resourcehash();
+
+        $metadata->delete();
+
+        // Records should be deleted.
+        $baserecord = $DB->get_record(\metadataextractor_tika\metadata_mock::TABLE, ['id' => $id]);
+        $this->assertFalse($baserecord);
+        $supplementaryrecord = $DB->get_record(\metadataextractor_tika\metadata_mock::SUPPLEMENTARY_TABLE,
+            ['resourcehash' => $resourcehash]);
+        $this->assertFalse($supplementaryrecord);
+    }
+}

--- a/tests/server_test.php
+++ b/tests/server_test.php
@@ -32,7 +32,7 @@ defined('MOODLE_INTERNAL') || die();
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  * @group      metadataextractor_tika
  */
-class server_test extends advanced_testcase {
+class metadataextractor_tika_server_test extends advanced_testcase {
 
     public function setUp() {
         $this->resetAfterTest();

--- a/tests/tika_helper_test.php
+++ b/tests/tika_helper_test.php
@@ -1,0 +1,92 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Unit tests for tool_metadata tika_helper class.
+ *
+ * @package    metadataextractor_tika
+ * @copyright  2020 Tom Dickman <tomdickman@catalyst-au.net>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') || die();
+
+/**
+ * Unit tests for tool_metadata tika_helper class.
+ *
+ * @package    metadataextractor_tika
+ * @copyright  2020 Tom Dickman <tomdickman@catalyst-au.net>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @group      metadataextractor_tika
+ */
+class metadataextractor_tika_helper_test extends advanced_testcase {
+
+    public function setUp() {
+        $this->resetAfterTest();
+    }
+
+    /**
+     * Provider of test mimetypes for file types.
+     *
+     * @return array
+     */
+    public function filetype_provider() {
+        return [
+            'Text document' => ['application/vnd.openxmlformats-officedocument.wordprocessingml.document', 'document'],
+            'PDF' => ['application/pdf', 'pdf'],
+            'Presentation' => ['application/vnd.ms-powerpoint', 'presentation'],
+            'Spreadsheet' => ['application/vnd.ms-excel', 'spreadsheet'],
+            'Image' => ['image/jpeg', 'image'],
+            'Video' => ['video/mpeg', 'video'],
+            'Audio' => ['audio/mp4', 'audio'],
+            'Archive' => ['application/zip', 'archive'],
+            'Other' => ['application/faketestmimetype', 'other']
+        ];
+    }
+
+    /**
+     * @dataProvider filetype_provider
+     *
+     * Test getting file type from mimetype.
+     */
+    public function test_get_filetype($mimetype, $expected) {
+        $actual = \metadataextractor_tika\tika_helper::get_filetype($mimetype);
+
+        $this->assertEquals($expected, $actual);
+    }
+
+
+    /**
+     * @dataProvider filetype_provider
+     *
+     * @param $mimetype string the IANA mimetype
+     * @param $classsubstring
+     */
+    public function test_get_metadata_class($mimetype, $classsubstring) {
+        $actual = \metadataextractor_tika\tika_helper::get_metadata_class($mimetype);
+
+        // TODO: Update when support for extra file types is added.
+        if ($classsubstring != \metadataextractor_tika\tika_helper::FILETYPE_DOCUMENT) {
+            $expected = '\metadataextractor_tika\metadata';
+        } else {
+            $expected = '\metadataextractor_tika\metadata_' . $classsubstring;
+        }
+
+        $this->assertEquals($expected, $actual);
+    }
+
+
+}

--- a/version.php
+++ b/version.php
@@ -24,7 +24,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2020030200;        // The current plugin version (Date: YYYYMMDDXX)
+$plugin->version   = 2020030201;        // The current plugin version (Date: YYYYMMDDXX)
 $plugin->requires  = 2019110500;        // Requires this Moodle version
 $plugin->component = 'metadataextractor_tika';        // Full name of the plugin (used for diagnostics)
 $plugin->maturity = MATURITY_ALPHA;

--- a/version.php
+++ b/version.php
@@ -24,7 +24,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2020021101;        // The current plugin version (Date: YYYYMMDDXX)
+$plugin->version   = 2020030200;        // The current plugin version (Date: YYYYMMDDXX)
 $plugin->requires  = 2019110500;        // Requires this Moodle version
 $plugin->component = 'metadataextractor_tika';        // Full name of the plugin (used for diagnostics)
 $plugin->maturity = MATURITY_ALPHA;

--- a/version.php
+++ b/version.php
@@ -24,9 +24,9 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2020030201;        // The current plugin version (Date: YYYYMMDDXX)
+$plugin->version   = 2020031001;        // The current plugin version (Date: YYYYMMDDXX)
 $plugin->requires  = 2019110500;        // Requires this Moodle version
 $plugin->component = 'metadataextractor_tika';        // Full name of the plugin (used for diagnostics)
 $plugin->maturity = MATURITY_ALPHA;
 
-$plugin->dependencies = array('tool_metadata' => 2020021101);
+$plugin->dependencies = array('tool_metadata' => 2020031001);

--- a/version.php
+++ b/version.php
@@ -24,9 +24,9 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2020031001;        // The current plugin version (Date: YYYYMMDDXX)
+$plugin->version   = 2020031101;        // The current plugin version (Date: YYYYMMDDXX)
 $plugin->requires  = 2019110500;        // Requires this Moodle version
 $plugin->component = 'metadataextractor_tika';        // Full name of the plugin (used for diagnostics)
 $plugin->maturity = MATURITY_ALPHA;
 
-$plugin->dependencies = array('tool_metadata' => 2020031001);
+$plugin->dependencies = array('tool_metadata' => 2020031101);


### PR DESCRIPTION
The base metadata fields extracted from all resources by this plugin provide only a small amount of the available metadata which can be extracted by Tika.
In order to avoid having too many `null` values in the database, these fields were originally limited to only those which most resources would be able to provide values for.

This feature introduces supplementary tables and associated metadata classes extending the base metadata class, which allows us to add new fields in a supplementary table for specific file resources based on their type (extrapolated from the mimetype Tika determines the file to have).

The first supported file type with the introduction of this feature is that of `document` type, covering MS Word, Open Office and other document mimetypes.