### PR TITLE
bug: issue with parsing presentations with embedded media

### DIFF
--- a/classes/server.php
+++ b/classes/server.php
@@ -132,14 +132,9 @@ class server {
     public function get_file_metadata(stored_file $file) {
 
         try {
-            $response = $this->client->request('POST', "$this->baseuri/meta/form", [
+            $response = $this->client->request('PUT', "$this->baseuri/meta", [
                 'headers' => ['Accept' => 'application/json'],
-                'multipart' => [
-                    [
-                        'name' => $file->get_filename(),
-                        'contents' => $file->get_content_file_handle(),
-                    ],
-                ],
+                'body' => $file->get_content_file_handle(),
             ]);
         } catch (\Exception $e) {
             if (method_exists($e, 'getReasonPhrase')) {


### PR DESCRIPTION
Tika server was returning an HTTP response code of 500 when
parsing presentation files (ie. mimetype of 'application/vnd.ms-powerpoint',
'application/vnd.oasis.opendocument.presentation' or
'application/vnd.openxmlformats-officedocument.presentationml.presentation')
containing embedded media files.

Altered server class logic to utilise Tika server API PUT method to
/meta endpoint, rather than multi-part form data to /meta/form endpoint.

Resolves #17